### PR TITLE
Swap dropdowns

### DIFF
--- a/src/app.R
+++ b/src/app.R
@@ -674,7 +674,9 @@ server <- function(input, output, session) {
                       inputId = "Zielpopulation",
                       label = "Zielpopulation",
                       choices = zielpopulationen,
-                      selected = selectedZielpopulation())
+                      selected = ifelse(selectedZielpopulation() %in% zielpopulationen,
+                                        selectedZielpopulation(),
+                                        zielpopulationen[1]))
     
     updateSelectInput(session,
                       inputId = "Kennwert",

--- a/src/app_english.R
+++ b/src/app_english.R
@@ -724,7 +724,9 @@ server <- function(input, output, session) {
                       inputId = "Zielpopulation",
                       label = "Population",
                       choices = zielpopulationen,
-                      selected = selectedZielpopulation())
+                      selected = ifelse(selectedZielpopulation() %in% zielpopulationen,
+                                        selectedZielpopulation(),
+                                        zielpopulationen[1]))
     
     updateSelectInput(session,
                       inputId = "Kennwert",


### PR DESCRIPTION
Swapped the dropdown menus for target population and parameter. Parameter now depends on target population (instead of the other way around) and only shows the available parameters that we have data for considering the selected target population.

![grafik](https://github.com/user-attachments/assets/8ab7620f-4ef8-4789-ace9-2610b70eebea)


Closes #5 