### PR TITLE
Deployment fix

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -25,6 +25,8 @@ COPY .Rbuildignore /tmp/BTShinyApp/.Rbuildignore
 # Install the Shiny app package (including dependencies from DESCRIPTION)
 RUN R -e "devtools::install_local('/tmp/BTShinyApp', dependencies = TRUE)"
 
+RUN Rscript -e "remotes::install_github('franikowsp/eatMap')"
+
 RUN rm -rf /tmp/BTShinyApp
 
 # Copy only the app entry point to Shiny server directory

--- a/Dockerfile
+++ b/Dockerfile
@@ -6,13 +6,10 @@ RUN rm -rf /srv/shiny-server/*
 # Install system libraries needed by common R packages
 RUN apt-get update && apt-get install -y \
     libudunits2-dev libproj-dev libgdal-dev \
-    libharfbuzz-dev libfribidi-dev cmake \
+    libharfbuzz-dev libfribidi-dev cmake texlive-xetex \
     less wget vim && \
     apt-get clean && \
     rm -rf /var/lib/apt/lists/*
-
-# Install LaTeX
-RUN R -e "install.packages('tinytex'); tinytex::install_tinytex(bundle = 'TinyTeX')"
 
 COPY R /tmp/BTShinyApp/R
 COPY data /tmp/BTShinyApp/data

--- a/inst/BT_Shiny_App/app.R
+++ b/inst/BT_Shiny_App/app.R
@@ -28,9 +28,6 @@ library(stringr)
 
 library(bslib)
 
-if (!requireNamespace("eatMap", quietly = TRUE)) {
-  remotes::install_github("franikowsp/eatMap")
-}
 library(eatMap)
 
 if (!requireNamespace("BTShinyApp", quietly = TRUE)) {


### PR DESCRIPTION
Hier ist meine Lösung. Schaut mal, ob ihr so akzeptabel findet und v.a. ob ich die alte Installationsart von eatMap richtig ausgebaut habe. So funktioniert das ganze jedenfalls erstmal.
- Das eatMap-Paket wird explizit installiert und das bevor die Anwendung läuft.
- Statt tinytex wird das texlive-Paket vom normalen Paketmanager benutzt.